### PR TITLE
Fix chat scroll-to-bottom with a temporary hack

### DIFF
--- a/public/sample-app/sampleapp-components/js/sample-app-helper-functions.js
+++ b/public/sample-app/sampleapp-components/js/sample-app-helper-functions.js
@@ -93,7 +93,14 @@ $(document).ready(function () {
     });
 
     $('#messages').live('contentchanged', function(){
-        scrollToBottom('messages');
+        /* 
+           FIXME This is triggered before the DOM is actually updated. Hack
+           around it by delaying for 100ms. This is of course not reliable but
+           will be good enough for demos.
+        */
+        setTimeout(function () {
+            scrollToBottom('messages');
+        }, 100);
 
     });
 


### PR DESCRIPTION
This fixes the problem where the chat log is always one message behind, but it doesn't fix it the right way. The problem is that the `contentchanged` event is fired before the new chat message element is actually inserted into the DOM, so the scroll-to-bottom logic calculates the wrong bottom y-position. I don't understand enough about the frameworks involved to implement a proper fix, but inserting a 100ms delay works around the problem in practice. Obviously this should be fixed properly, but I offer this PR just in case you want to hack it for now. :) Please feel free to close this without accepting.